### PR TITLE
Add build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools",
+    "cython",
+    "numpy",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
+[project]
+name = "ssw-py"
+
 [build-system]
 requires = [
-    "setuptools",
+    "setuptools<65.6.0",
+    "wheel",
     "cython",
     "numpy",
 ]

--- a/ssw/__init__.py
+++ b/ssw/__init__.py
@@ -3,4 +3,4 @@ from .sswpy import *
 __author__ = 'Nick Conway'
 __copyright__ = 'Copyright 2018, Nick Conway; Wyss Institute Harvard University'
 __license__ = 'MIT'
-__version__ = '0.2.6'
+__version__ = '0.2.7'


### PR DESCRIPTION
Adds a `pyproject.toml` containing build time requirements. This is needed because `setup.py` imports from `numpy` which won't be installed in a fresh venv. This made this library (and packages that depend on it- in our case aldy) difficult to package without a custom build process.

With this change doing a `pip install path/to/ssw-py` in a fresh venv works without first installing numpy and cython.  